### PR TITLE
fix: Поведение камеры в начале игры и при переключении персонажей

### DIFF
--- a/Source/G2I/Private/Components/Camera/G2ICameraControllerComponent.cpp
+++ b/Source/G2I/Private/Components/Camera/G2ICameraControllerComponent.cpp
@@ -180,7 +180,8 @@ bool UG2ICameraControllerComponent::SetCamera(const UCameraComponent& NewCamera)
 		return false;
 	}
 	
-	PlayerController->SetViewTargetWithBlend(OwnerActor, CameraDefaultsParameters->CameraTransitionTime);
+	PlayerController->SetViewTargetWithBlend(OwnerActor, CameraDefaultsParameters->CameraTransitionTime,
+		VTBlend_Linear, 0, true);
 	PlayerController->SetRotationTowardsCamera(NewCamera);
 	return true;
 }

--- a/Source/G2I/Private/Controls/G2IPlayerCameraManager.cpp
+++ b/Source/G2I/Private/Controls/G2IPlayerCameraManager.cpp
@@ -1,0 +1,9 @@
+#include "G2IPlayerCameraManager.h"
+
+void AG2IPlayerCameraManager::SetViewTarget(class AActor* NewViewTarget, FViewTargetTransitionParams TransitionParams)
+{
+	if (NewViewTarget)
+	{
+		Super::SetViewTarget(NewViewTarget, TransitionParams);
+	}
+}

--- a/Source/G2I/Private/Controls/G2IPlayerController.cpp
+++ b/Source/G2I/Private/Controls/G2IPlayerController.cpp
@@ -2,6 +2,7 @@
 #include "EnhancedInputComponent.h"
 #include "EnhancedInputSubsystems.h"
 #include "G2I.h"
+#include "G2IPlayerCameraManager.h"
 #include "Camera/G2IThirdPersonCameraInputInterface.h"
 #include "G2IPlayerState.h"
 #include "Engine/LocalPlayer.h"
@@ -65,12 +66,44 @@ void AG2IPlayerController::SetupInputComponent()
 	}
 }
 
+AG2IPlayerController::AG2IPlayerController()
+{
+	PlayerCameraManagerClass = AG2IPlayerCameraManager::StaticClass();
+}
+
 void AG2IPlayerController::OnPossess(APawn* NewPawn)
 {
 	Super::OnPossess(NewPawn);
 
 	SetupCharacterActorComponents();
 	SetupCamera();
+}
+
+void AG2IPlayerController::OnUnPossess()
+{
+	// Differs from the default function by the absence of setting of the view target in Player Controller
+	if (APawn *CurrentPawn = GetPawn())
+	{
+		if (GetLocalRole() == ROLE_Authority)
+		{
+			CurrentPawn->SetReplicates(true);
+		}
+		CurrentPawn->UnPossessed();
+	}
+	SetPawn(nullptr);
+}
+
+void AG2IPlayerController::SetViewTargetWithBlend(class AActor* NewViewTarget, float BlendTime,
+	enum EViewTargetBlendFunction BlendFunc, float BlendExp, bool bLockOutgoing)
+{
+	if (GetViewTarget() != this)
+	{
+		Super::SetViewTargetWithBlend(NewViewTarget, BlendTime, BlendFunc, BlendExp, bLockOutgoing);
+	}
+	else
+	{
+		SetViewTarget(NewViewTarget);
+	}
 }
 
 void AG2IPlayerController::SetRotationTowardsCamera(const UCameraComponent& Camera)

--- a/Source/G2I/Public/Controls/G2IPlayerCameraManager.h
+++ b/Source/G2I/Public/Controls/G2IPlayerCameraManager.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Camera/PlayerCameraManager.h"
+#include "G2IPlayerCameraManager.generated.h"
+
+/**
+ * Basic Player Camera Manager
+ * Doesn't switch on Player Controller when trying setting empty camera
+ */
+UCLASS()
+class G2I_API AG2IPlayerCameraManager : public APlayerCameraManager
+{
+	GENERATED_BODY()
+
+public:
+
+	virtual void SetViewTarget(AActor* NewViewTarget,
+		FViewTargetTransitionParams TransitionParams = FViewTargetTransitionParams()) override;
+	
+};

--- a/Source/G2I/Public/Controls/G2IPlayerController.h
+++ b/Source/G2I/Public/Controls/G2IPlayerController.h
@@ -27,7 +27,14 @@ private:
 	
 public:
 
+	AG2IPlayerController();
+
 	virtual void OnPossess(APawn *NewPawn) override;
+
+	virtual void OnUnPossess() override;
+
+	virtual void SetViewTargetWithBlend(AActor* NewViewTarget, float BlendTime = 0,
+		EViewTargetBlendFunction BlendFunc = VTBlend_Linear, float BlendExp = 0, bool bLockOutgoing = false) override;
 
 public:
 


### PR DESCRIPTION
Close #89 

Теперь:
1. Камера в начале игры больше не стартует из центра персонажа:

_Переопределила в PlayerCameraManager SetViewTarget(), чтобы он не мог переключаться на пустую камеру (какая по умолчанию в начале игры)_

2. Камера в начале игры не поворачивается откуда-то к нужной стартовой:

_Переопределила в PlayerController SetViewTargetWithBlend(), чтобы он не использовал бленд при переключении из PlayerController (который устанавливается по умолчанию в начале игры)_

3. Камера при переключении между персонажами больше не стартует из центра:

_Переопределила в PlayerController OnUnPossess(), убрав при откреплении персонажа от контроллера переключение камеры с персонажа на контроллер (как есть по умолчанию)_

4. Камера от третьего лица поворачивается из текущего положения, а не из-за спины персонажа:

_Стало вызываться SetViewTargetWithBlend() с флагом bool bLockOutgoing = true, который определяет нужно ли переключаться при переходе на положение камеры по умолчанию_