### PR TITLE
fix: Прекратить целиться после переключения персонажей

### DIFF
--- a/Source/G2I/Private/Characters/G2ICharacterDaughter.cpp
+++ b/Source/G2I/Private/Characters/G2ICharacterDaughter.cpp
@@ -29,3 +29,27 @@ AG2ICharacterDaughter::AG2ICharacterDaughter(const FObjectInitializer& ObjectIni
 
 	MovementComp->SetCanPassThroughObject(true);
 }
+
+void AG2ICharacterDaughter::PossessedBy(AController* NewController)
+{
+	Super::PossessedBy(NewController);
+
+	OnPossessedDelegate.Broadcast(NewController);
+}
+
+void AG2ICharacterDaughter::UnPossessed()
+{
+	Super::UnPossessed();
+
+	OnUnPossessedDelegate.Broadcast();
+}
+
+FPossessedDelegate& AG2ICharacterDaughter::GetPossessedDelegate()
+{
+	return OnPossessedDelegate;
+}
+
+FUnPossessedDelegate& AG2ICharacterDaughter::GetUnPossessedDelegate()
+{
+	return OnUnPossessedDelegate;
+}

--- a/Source/G2I/Private/Characters/G2ICharacterEngineer.cpp
+++ b/Source/G2I/Private/Characters/G2ICharacterEngineer.cpp
@@ -21,3 +21,27 @@ AG2ICharacterEngineer::AG2ICharacterEngineer(const FObjectInitializer& ObjectIni
 	HoleInteractionComp = CreateDefaultSubobject<UG2IHoleInteractionComponent>(FName("HoleInteractionComp"));
 	SteamGloveComp = CreateDefaultSubobject<UG2ISteamGloveComponent>(FName("SteamGloveComp"));
 }
+
+void AG2ICharacterEngineer::PossessedBy(AController* NewController)
+{
+	Super::PossessedBy(NewController);
+
+	OnPossessedDelegate.Broadcast(NewController);
+}
+
+void AG2ICharacterEngineer::UnPossessed()
+{
+	Super::UnPossessed();
+
+	OnUnPossessedDelegate.Broadcast();
+}
+
+FPossessedDelegate& AG2ICharacterEngineer::GetPossessedDelegate()
+{
+	return OnPossessedDelegate;
+}
+
+FUnPossessedDelegate& AG2ICharacterEngineer::GetUnPossessedDelegate()
+{
+	return OnUnPossessedDelegate;
+}

--- a/Source/G2I/Private/Components/SteamGlove/G2IAimingComponent.cpp
+++ b/Source/G2I/Private/Components/SteamGlove/G2IAimingComponent.cpp
@@ -6,6 +6,7 @@
 #include "G2ISteamShotComponent.h"
 #include "Blueprint/UserWidget.h"
 #include "G2ICameraControllerComponent.h"
+#include "G2ICharacterInterface.h"
 
 UG2IAimingComponent::UG2IAimingComponent()
 {
@@ -92,11 +93,21 @@ void UG2IAimingComponent::SetupDefaults()
 
 void UG2IAimingComponent::BindDelegates()
 {
-	const AActor *Owner = GetOwner();
+	AActor *Owner = GetOwner();
 	if (!ensure(Owner))
 	{
 		UE_LOG(LogG2I, Error, TEXT("Owner doesn't exist in %s"), *GetName());
 		return;
+	}
+
+	if (IG2ICharacterInterface *CharacterOwner = Cast<IG2ICharacterInterface>(Owner))
+	{
+		CharacterOwner->GetUnPossessedDelegate().AddDynamic(this, &ThisClass::StopAimingAction_Implementation);
+	}
+	else
+	{
+		UE_LOG(LogG2I, Warning, TEXT("Owner %s of %s doesn't implement %s interface"),
+			*Owner->GetActorNameOrLabel(), *GetName(), *UG2ICharacterInterface::StaticClass()->GetName());
 	}
 	
 	if (UG2ICameraControllerComponent *CameraControllerComponent = Owner->FindComponentByClass<UG2ICameraControllerComponent>())

--- a/Source/G2I/Private/Interfaces/G2ICharacterInterface.cpp
+++ b/Source/G2I/Private/Interfaces/G2ICharacterInterface.cpp
@@ -1,0 +1,1 @@
+#include "G2ICharacterInterface.h"

--- a/Source/G2I/Public/Characters/G2ICharacterDaughter.h
+++ b/Source/G2I/Public/Characters/G2ICharacterDaughter.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include "CoreMinimal.h"
+#include "G2ICharacterInterface.h"
 #include "GameFramework/Character.h"
 #include "G2ICharacterDaughter.generated.h"
 
@@ -16,7 +17,7 @@ class UG2IInteractionComponent;
  *  Implements a controllable orbiting camera
  */
 UCLASS(Blueprintable)
-class AG2ICharacterDaughter : public ACharacter
+class AG2ICharacterDaughter : public ACharacter, public IG2ICharacterInterface
 {
 	GENERATED_BODY()
 
@@ -38,9 +39,27 @@ public:
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = Camera)
 	TObjectPtr<UG2IFixedCamerasComponent> FixedCamerasComp;
 
+private:
+
+	UPROPERTY(BlueprintAssignable)
+	FPossessedDelegate OnPossessedDelegate;
+
+	UPROPERTY(BlueprintAssignable)
+	FUnPossessedDelegate OnUnPossessedDelegate;
+
 public:
 
 	explicit AG2ICharacterDaughter(const FObjectInitializer& ObjectInitializer = FObjectInitializer::Get());
+
+	virtual void PossessedBy(AController* NewController) override;
+	
+	virtual void UnPossessed() override;
+	
+	UFUNCTION()
+	virtual FPossessedDelegate& GetPossessedDelegate() override;
+
+	UFUNCTION()
+	virtual FUnPossessedDelegate& GetUnPossessedDelegate() override;
 	
 };
 

--- a/Source/G2I/Public/Characters/G2ICharacterEngineer.h
+++ b/Source/G2I/Public/Characters/G2ICharacterEngineer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "G2ICharacterInterface.h"
 #include "GameFramework/Character.h"
 #include "Components/G2IValveInteractionComponent.h"
 #include "Components/G2IHoleInteractionComponent.h"
@@ -18,7 +19,7 @@ class UG2IInteractionComponent;
  *  Implements a controllable orbiting camera
  */
 UCLASS(Blueprintable)
-class G2I_API AG2ICharacterEngineer : public ACharacter
+class G2I_API AG2ICharacterEngineer : public ACharacter, public IG2ICharacterInterface
 {
 	GENERATED_BODY()
 
@@ -49,9 +50,27 @@ public:
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = Camera)
 	TObjectPtr<UG2IFixedCamerasComponent> FixedCamerasComp;
 
-protected:
+private:
+
+	UPROPERTY(BlueprintAssignable)
+	FPossessedDelegate OnPossessedDelegate;
+
+	UPROPERTY(BlueprintAssignable)
+	FUnPossessedDelegate OnUnPossessedDelegate;
+
+public:
 
 	explicit AG2ICharacterEngineer(const FObjectInitializer& ObjectInitializer = FObjectInitializer::Get());
+
+	virtual void PossessedBy(AController* NewController) override;
+	
+	virtual void UnPossessed() override;
+	
+	UFUNCTION()
+	virtual FPossessedDelegate& GetPossessedDelegate() override;
+
+	UFUNCTION()
+	virtual FUnPossessedDelegate& GetUnPossessedDelegate() override;
 	
 };
 

--- a/Source/G2I/Public/Interfaces/G2ICharacterInterface.h
+++ b/Source/G2I/Public/Interfaces/G2ICharacterInterface.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/Interface.h"
+#include "G2ICharacterInterface.generated.h"
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FPossessedDelegate, AController *, NewController);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FUnPossessedDelegate);
+
+UINTERFACE()
+class UG2ICharacterInterface : public UInterface
+{
+	GENERATED_BODY()
+};
+
+/**
+ * Interface for delegates of standard character functions
+ * that are not visible to the actor components of this character
+ */
+class G2I_API IG2ICharacterInterface
+{
+	GENERATED_BODY()
+
+public:
+
+	UFUNCTION()
+	virtual FPossessedDelegate& GetPossessedDelegate() = 0;
+
+	UFUNCTION()
+	virtual FUnPossessedDelegate& GetUnPossessedDelegate() = 0;
+	
+};


### PR DESCRIPTION
Close #164 
1. Добавила интерфейс CharacterInterface, который можно использовать для передачи делегатов от любых персонажей.
Например, из функций, которые вызываются в персонажах, но не видны в их актор компонентах или других классах.
Это не первое место, где такое требовалось.

2. После отсоединения персонажа от плеер контроллера вызвала прекращение прицеливания