### PR TITLE
fix: Disable aiming during blend transition

### DIFF
--- a/Source/G2I/Private/Components/Camera/G2ICameraControllerComponent.cpp
+++ b/Source/G2I/Private/Components/Camera/G2ICameraControllerComponent.cpp
@@ -142,6 +142,16 @@ void UG2ICameraControllerComponent::RemoveCamera(UCameraComponent* RemovedCamera
 	}
 }
 
+void UG2ICameraControllerComponent::BroadcastCameraTypeAfterBlendFinish()
+{
+	OnSetCameraTypeDelegate.Broadcast(CurrentCameraType, EG2ICameraBlendState::Finish);
+}
+
+void UG2ICameraControllerComponent::BroadcastCameraTypeAtBlendStart()
+{
+	OnSetCameraTypeDelegate.Broadcast(CurrentCameraType, EG2ICameraBlendState::Start);
+}
+
 bool UG2ICameraControllerComponent::IsOwnerControllable() const
 {
 	if (!ensure(Owner))
@@ -179,10 +189,6 @@ bool UG2ICameraControllerComponent::SetCamera(const UCameraComponent& NewCamera)
 		UE_LOG(LogG2I, Error, TEXT("Player Controller doesn't exist in %s"), *GetName());
 		return false;
 	}
-	
-	PlayerController->SetViewTargetWithBlend(OwnerActor, CameraDefaultsParameters->CameraTransitionTime,
-		VTBlend_Linear, 0, true);
-	PlayerController->SetRotationTowardsCamera(NewCamera);
 
 	if (OwnerActor == Owner.Get())
 	{
@@ -192,7 +198,11 @@ bool UG2ICameraControllerComponent::SetCamera(const UCameraComponent& NewCamera)
 	{
 		CurrentCameraType = EG2ICameraTypeEnum::FixedCamera;
 	}
-	OnSetCameraTypeDelegate.Broadcast(CurrentCameraType);
+	BroadcastCameraTypeAtBlendStart();
+	
+	PlayerController->SetViewTargetWithBlend(OwnerActor, CameraDefaultsParameters->CameraTransitionTime,
+		VTBlend_Linear, 0, true);
+	PlayerController->SetRotationTowardsCamera(NewCamera);
 	
 	return true;
 }
@@ -276,6 +286,8 @@ void UG2ICameraControllerComponent::SetupDefaults()
 
 void UG2ICameraControllerComponent::BindDelegates()
 {
+	BindPlayerControllerDelegates();
+	
 	if (!ensure(Owner))
 	{
 		UE_LOG(LogG2I, Error, TEXT("Owner doesn't exist in %s"), *GetName());
@@ -294,6 +306,25 @@ void UG2ICameraControllerComponent::BindDelegates()
 				&ThisClass::UG2ICameraControllerComponent::RemoveCamera);
 		}
 	}
+}
+
+void UG2ICameraControllerComponent::BindPlayerControllerDelegates()
+{
+	if (!ensure(PlayerController))
+	{
+		UE_LOG(LogG2I, Error, TEXT("Player Controller doesn't exist in %s"), *GetName());
+		return;
+	}
+	
+	const APlayerCameraManager *PlayerCameraManager = PlayerController->PlayerCameraManager;
+	if (!ensure(PlayerCameraManager))
+	{
+		UE_LOG(LogG2I, Error, TEXT("Player Controller %s doesn't have Player Camera Manager in %s"),
+			*PlayerController->GetActorNameOrLabel(), *GetName());
+		return;
+	}
+
+	PlayerCameraManager->OnBlendComplete().AddUObject(this, &ThisClass::BroadcastCameraTypeAfterBlendFinish);
 }
 
 void UG2ICameraControllerComponent::SetupCamerasDefaults()

--- a/Source/G2I/Private/Components/G2ICharacterMovementComponent.cpp
+++ b/Source/G2I/Private/Components/G2ICharacterMovementComponent.cpp
@@ -7,6 +7,7 @@
 #include "GameFramework/PlayerController.h"
 #include "G2IAimingComponent.h"
 #include "G2ICameraControllerComponent.h"
+#include "G2ICameraStateEnums.h"
 #include "Components/CapsuleComponent.h"
 
 UG2ICharacterMovementComponent::UG2ICharacterMovementComponent()
@@ -474,19 +475,23 @@ void UG2ICharacterMovementComponent::DisableRotationTowardsCamera()
 	Owner->bUseControllerRotationRoll = false;
 }
 
-void UG2ICharacterMovementComponent::SetAbilityRotationTowardsCamera(EG2ICameraTypeEnum CurrentCamera)
+void UG2ICharacterMovementComponent::SetAbilityRotationTowardsCamera(
+	EG2ICameraTypeEnum CurrentCameraType, EG2ICameraBlendState CurrentBlendState)
 {
-	if (CurrentCamera == EG2ICameraTypeEnum::ThirdPersonCamera)
+	if (CurrentCameraType == EG2ICameraTypeEnum::ThirdPersonCamera && CurrentBlendState == EG2ICameraBlendState::Finish)
 	{
 		bCanRotationTowardsCamera = true;
 		if (bWantsRotationTowardsCamera)
 		{
 			EnableRotationTowardsCamera();
 		}
+		return;
 	}
-	else
+	
+	if (CurrentCameraType == EG2ICameraTypeEnum::FixedCamera && CurrentBlendState == EG2ICameraBlendState::Start)
 	{
 		bCanRotationTowardsCamera = false;
 		DisableRotationTowardsCamera();
+		return;
 	}
 }

--- a/Source/G2I/Private/Components/SteamGlove/G2IAimingComponent.cpp
+++ b/Source/G2I/Private/Components/SteamGlove/G2IAimingComponent.cpp
@@ -6,6 +6,7 @@
 #include "G2ISteamShotComponent.h"
 #include "Blueprint/UserWidget.h"
 #include "G2ICameraControllerComponent.h"
+#include "G2ICameraStateEnums.h"
 #include "G2ICharacterInterface.h"
 
 UG2IAimingComponent::UG2IAimingComponent()
@@ -178,17 +179,19 @@ UActorComponent *UG2IAimingComponent::GetCurrentComponentUsingAim_Implementation
 	return nullptr;
 }
 
-void UG2IAimingComponent::SetAbilityAiming(EG2ICameraTypeEnum CurrentCameraType)
+void UG2IAimingComponent::SetAbilityAiming(EG2ICameraTypeEnum CurrentCameraType, EG2ICameraBlendState CurrentBlendState)
 {
-	if (CurrentCameraType == EG2ICameraTypeEnum::ThirdPersonCamera)
+	if (CurrentCameraType == EG2ICameraTypeEnum::ThirdPersonCamera && CurrentBlendState == EG2ICameraBlendState::Finish)
 	{
 		bCanAiming = true;
 		if (bWantsAiming)
 		{
 			StartAimingAction_Implementation();
 		}
+		return;
 	}
-	else
+
+	if (CurrentCameraType == EG2ICameraTypeEnum::FixedCamera && CurrentBlendState == EG2ICameraBlendState::Start)
 	{
 		bCanAiming = false;
 		if (bIsAiming)
@@ -196,6 +199,7 @@ void UG2IAimingComponent::SetAbilityAiming(EG2ICameraTypeEnum CurrentCameraType)
 			StopAimingAction_Implementation();
 			bWantsAiming = true;
 		}
+		return;
 	}
 }
 

--- a/Source/G2I/Private/DataDefinitions/Enums/G2ICameraStateEnums.cpp
+++ b/Source/G2I/Private/DataDefinitions/Enums/G2ICameraStateEnums.cpp
@@ -1,0 +1,1 @@
+#include "G2ICameraStateEnums.h"

--- a/Source/G2I/Private/DataDefinitions/G2ICameraTypeEnum.cpp
+++ b/Source/G2I/Private/DataDefinitions/G2ICameraTypeEnum.cpp
@@ -1,1 +1,0 @@
-#include "G2ICameraTypeEnum.h"

--- a/Source/G2I/Public/Components/Camera/G2ICameraControllerComponent.h
+++ b/Source/G2I/Public/Components/Camera/G2ICameraControllerComponent.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "G2ICameraTypeEnum.h"
 #include "G2ICameraControllerInputInterface.h"
+#include "G2ICameraStateEnums.h"
 #include "Components/ActorComponent.h"
 #include "G2ICameraControllerComponent.generated.h"
 
@@ -12,7 +12,8 @@ class UCameraComponent;
 class UG2IFixedCamerasComponent;
 class UG2IThirdPersonCameraComponent;
 
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FSetCameraTypeDelegate, EG2ICameraTypeEnum, CurrentCameraType);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FSetCameraTypeDelegate, EG2ICameraTypeEnum, CurrentCameraType,
+	EG2ICameraBlendState, CurrentBlendState);
 
 UCLASS(ClassGroup=(Camera), meta=(BlueprintSpawnableComponent))
 class G2I_API UG2ICameraControllerComponent : public UActorComponent, public IG2ICameraControllerInputInterface
@@ -69,6 +70,11 @@ private:
 	UFUNCTION()
 	void RemoveCamera(UCameraComponent *RemovedCamera);
 
+	UFUNCTION()
+	void BroadcastCameraTypeAfterBlendFinish();
+
+	void BroadcastCameraTypeAtBlendStart();
+
 	bool IsOwnerControllable() const;
 
 	bool SetCamera(const UCameraComponent& NewCamera);
@@ -78,6 +84,7 @@ private:
 	void SetupDefaults();
 	
 	void BindDelegates();
+	void BindPlayerControllerDelegates();
 
 	void SetupCamerasDefaults();
 

--- a/Source/G2I/Public/Components/G2ICharacterMovementComponent.h
+++ b/Source/G2I/Public/Components/G2ICharacterMovementComponent.h
@@ -6,6 +6,7 @@
 #include "GameFramework/CharacterMovementComponent.h"
 #include "G2ICharacterMovementComponent.generated.h"
 
+enum class EG2ICameraBlendState : uint8;
 enum class EG2ICameraTypeEnum : uint8;
 class UCharacterMovementComponent;
 
@@ -114,7 +115,7 @@ protected:
 	void DisableRotationTowardsCamera();
 
 	UFUNCTION()
-	void SetAbilityRotationTowardsCamera(EG2ICameraTypeEnum CurrentCamera);
+	void SetAbilityRotationTowardsCamera(EG2ICameraTypeEnum CurrentCameraType, EG2ICameraBlendState CurrentBlendState);
 
 private:
 

--- a/Source/G2I/Public/Components/SteamGlove/G2IAimingComponent.h
+++ b/Source/G2I/Public/Components/SteamGlove/G2IAimingComponent.h
@@ -7,6 +7,7 @@
 #include "G2IAimTypeEnum.h"
 #include "G2IAimingComponent.generated.h"
 
+enum class EG2ICameraBlendState : uint8;
 enum class EG2IAimType : uint8;
 enum class EG2ICameraTypeEnum : uint8;
 class UG2IAimingWidget;
@@ -101,7 +102,7 @@ public:
 protected:
 
 	UFUNCTION()
-	void SetAbilityAiming(EG2ICameraTypeEnum CurrentCameraType);
+	void SetAbilityAiming(EG2ICameraTypeEnum CurrentCameraType, EG2ICameraBlendState CurrentBlendState);
 	
 	UFUNCTION()
 	void SetAimDistance(const float NewAimDistance);

--- a/Source/G2I/Public/DataDefinitions/Enums/G2ICameraStateEnums.h
+++ b/Source/G2I/Public/DataDefinitions/Enums/G2ICameraStateEnums.h
@@ -1,0 +1,15 @@
+#pragma once
+
+UENUM(BlueprintType)
+enum class EG2ICameraTypeEnum : uint8
+{
+	ThirdPersonCamera UMETA(DisplayName = "Third-Person Camera"),
+	FixedCamera UMETA(DisplayName = "Fixed Camera")
+};
+
+UENUM(BlueprintType)
+enum class EG2ICameraBlendState : uint8
+{
+	Start UMETA(DisplayName = "Start blend transition of camera"),
+	Finish UMETA(DisplayName = "Finish blend transition of camera")
+};

--- a/Source/G2I/Public/DataDefinitions/Enums/G2ICameraTypeEnum.h
+++ b/Source/G2I/Public/DataDefinitions/Enums/G2ICameraTypeEnum.h
@@ -1,8 +1,0 @@
-#pragma once
-
-UENUM(BlueprintType)
-enum class EG2ICameraTypeEnum : uint8
-{
-	ThirdPersonCamera UMETA(DisplayName = "Third-Person Camera"),
-	FixedCamera UMETA(DisplayName = "Fixed Camera")
-};


### PR DESCRIPTION
Close #168 

Прицеливание теперь не работает во время перехода между камерами

Нет вот такого:
<img width="1062" height="653" alt="image" src="https://github.com/user-attachments/assets/04b3c490-e6a3-4656-ac79-8ef5c0ac8a39" />
