### PR TITLE
feat: Задержка перемещения при переключении на фиксированную камеру

### DIFF
--- a/Source/G2I/Private/Components/Camera/G2ICameraControllerComponent.cpp
+++ b/Source/G2I/Private/Components/Camera/G2ICameraControllerComponent.cpp
@@ -18,8 +18,6 @@ UG2ICameraControllerComponent::UG2ICameraControllerComponent()
 void UG2ICameraControllerComponent::BeginPlay()
 {
 	Super::BeginPlay();
-	
-	PrimaryComponentTick.bCanEverTick = true;
 
 	BindDelegates();
 	SetupCamerasDefaults();
@@ -60,22 +58,6 @@ void UG2ICameraControllerComponent::PreInitializationDefaults()
 		return;
 	}
 	GameInstance->OnStartLevelInitDelegate.AddUObject(this, &ThisClass::SetupDefaults);
-}
-
-void UG2ICameraControllerComponent::TickComponent(float DeltaTime, ELevelTick TickType,
-	FActorComponentTickFunction* ThisTickFunction)
-{
-	Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
-
-	if (IsOwnerControllable())
-	{
-		if (!CurrentCameraComponents.IsEmpty() &&
-			CurrentCameraComponents[CurrentCameraIndex % CurrentCameraComponents.Num()])
-		{
-			PlayerController->SetRotationTowardsCamera(
-				*CurrentCameraComponents[CurrentCameraIndex % CurrentCameraComponents.Num()]);
-		}
-	}
 }
 
 void UG2ICameraControllerComponent::SetupCurrentCamera_Implementation()
@@ -145,12 +127,34 @@ void UG2ICameraControllerComponent::RemoveCamera(UCameraComponent* RemovedCamera
 
 void UG2ICameraControllerComponent::BroadcastCameraTypeAfterBlendFinish()
 {
-	OnSetCameraTypeDelegate.Broadcast(CurrentCameraType, EG2ICameraBlendState::Finish);
+	const UCameraComponent *NewCamera = nullptr;
+	if (CurrentCameraComponents.IsValidIndex(CurrentCameraIndex))
+	{
+		NewCamera= CurrentCameraComponents[CurrentCameraIndex];
+	}
+		
+	switch (CurrentCameraType)
+	{
+	case EG2ICameraTypeEnum::ThirdPersonCamera:
+		OnSetThirdPersonCameraTypeDelegate.Broadcast(EG2ICameraBlendState::Finish, NewCamera);
+		break;
+	case EG2ICameraTypeEnum::FixedCamera:
+		OnSetFixedCameraTypeDelegate.Broadcast(EG2ICameraBlendState::Finish, NewCamera);
+		break;
+	}
 }
 
-void UG2ICameraControllerComponent::BroadcastCameraTypeAtBlendStart()
+void UG2ICameraControllerComponent::BroadcastCameraTypeAtBlendStart(const UCameraComponent& NewCamera) const
 {
-	OnSetCameraTypeDelegate.Broadcast(CurrentCameraType, EG2ICameraBlendState::Start);
+	switch (CurrentCameraType)
+	{
+	case EG2ICameraTypeEnum::ThirdPersonCamera:
+		OnSetThirdPersonCameraTypeDelegate.Broadcast(EG2ICameraBlendState::Start, &NewCamera);
+		break;
+	case EG2ICameraTypeEnum::FixedCamera:
+		OnSetFixedCameraTypeDelegate.Broadcast(EG2ICameraBlendState::Start, &NewCamera);
+		break;
+	}
 }
 
 bool UG2ICameraControllerComponent::IsOwnerControllable() const
@@ -199,11 +203,10 @@ bool UG2ICameraControllerComponent::SetCamera(const UCameraComponent& NewCamera)
 	{
 		CurrentCameraType = EG2ICameraTypeEnum::FixedCamera;
 	}
-	BroadcastCameraTypeAtBlendStart();
-	
+	SetThirdPersonCameraYawRotation();
+	BroadcastCameraTypeAtBlendStart(NewCamera);
 	PlayerController->SetViewTargetWithBlend(OwnerActor, CameraDefaultsParameters->CameraTransitionTime,
 		VTBlend_Linear, 0, true);
-	PlayerController->SetRotationTowardsCamera(NewCamera);
 	
 	return true;
 }
@@ -377,10 +380,5 @@ void UG2ICameraControllerComponent::SetThirdPersonCameraYawRotation()
 
 void UG2ICameraControllerComponent::SetCurrentCameraIndex(const int32 NewCameraIndex)
 {
-	if (CurrentCameraIndex == NewCameraIndex)
-	{
-		return;
-	}
-	SetThirdPersonCameraYawRotation();
 	CurrentCameraIndex = NewCameraIndex;
 }

--- a/Source/G2I/Private/Components/Camera/G2ICameraControllerComponent.cpp
+++ b/Source/G2I/Private/Components/Camera/G2ICameraControllerComponent.cpp
@@ -13,6 +13,7 @@
 UG2ICameraControllerComponent::UG2ICameraControllerComponent()
 {
 	bWantsInitializeComponent = true;
+	DelayMovementTime = 0.f;
 }
 
 void UG2ICameraControllerComponent::BeginPlay()
@@ -67,6 +68,7 @@ void UG2ICameraControllerComponent::SetupCurrentCamera_Implementation()
 
 void UG2ICameraControllerComponent::SwitchCameraBehavior_Implementation()
 {
+	DelayMovementTime = 0.f;
 	for (int32 CameraOffset = 1; CameraOffset < CurrentCameraComponents.Num(); ++CameraOffset)
 	{
 		const int32 NewCameraIndex = (CurrentCameraIndex + CameraOffset) % CurrentCameraComponents.Num();
@@ -139,12 +141,12 @@ void UG2ICameraControllerComponent::BroadcastCameraTypeAfterBlendFinish()
 		OnSetThirdPersonCameraTypeDelegate.Broadcast(EG2ICameraBlendState::Finish, NewCamera);
 		break;
 	case EG2ICameraTypeEnum::FixedCamera:
-		OnSetFixedCameraTypeDelegate.Broadcast(EG2ICameraBlendState::Finish, NewCamera);
+		OnSetFixedCameraTypeDelegate.Broadcast(EG2ICameraBlendState::Finish, NewCamera, DelayMovementTime);
 		break;
 	}
 }
 
-void UG2ICameraControllerComponent::BroadcastCameraTypeAtBlendStart(const UCameraComponent& NewCamera) const
+void UG2ICameraControllerComponent::BroadcastCameraTypeAtBlendStart(const UCameraComponent& NewCamera)
 {
 	switch (CurrentCameraType)
 	{
@@ -152,9 +154,10 @@ void UG2ICameraControllerComponent::BroadcastCameraTypeAtBlendStart(const UCamer
 		OnSetThirdPersonCameraTypeDelegate.Broadcast(EG2ICameraBlendState::Start, &NewCamera);
 		break;
 	case EG2ICameraTypeEnum::FixedCamera:
-		OnSetFixedCameraTypeDelegate.Broadcast(EG2ICameraBlendState::Start, &NewCamera);
+		OnSetFixedCameraTypeDelegate.Broadcast(EG2ICameraBlendState::Start, &NewCamera, DelayMovementTime);
 		break;
 	}
+	SetDefaultDelayMovementTime();
 }
 
 bool UG2ICameraControllerComponent::IsOwnerControllable() const
@@ -381,4 +384,15 @@ void UG2ICameraControllerComponent::SetThirdPersonCameraYawRotation()
 void UG2ICameraControllerComponent::SetCurrentCameraIndex(const int32 NewCameraIndex)
 {
 	CurrentCameraIndex = NewCameraIndex;
+}
+
+void UG2ICameraControllerComponent::SetDefaultDelayMovementTime()
+{
+	if (!ensure(CameraDefaultsParameters))
+	{
+		UE_LOG(LogG2I, Error, TEXT("%s: Couldn't find %s"), *GetName(),
+			*UG2ICameraDefaultsParameters::StaticClass()->GetName());
+		return;
+	}
+	DelayMovementTime = CameraDefaultsParameters->PendingTimeAfterSwitchingToControlCharacter;
 }

--- a/Source/G2I/Private/Components/G2ICharacterMovementComponent.cpp
+++ b/Source/G2I/Private/Components/G2ICharacterMovementComponent.cpp
@@ -7,7 +7,6 @@
 #include "GameFramework/PlayerController.h"
 #include "G2IAimingComponent.h"
 #include "G2ICameraControllerComponent.h"
-#include "G2ICameraDefaultsParameters.h"
 #include "G2ICameraStateEnums.h"
 #include "G2IPlayerController.h"
 #include "Components/CapsuleComponent.h"
@@ -50,14 +49,6 @@ void UG2ICharacterMovementComponent::SetupDefaults()
 	{
 		UE_LOG(LogG2I, Error, TEXT("%s: Couldn't find %s"),
 			*GetName(), *AG2IPlayerController::StaticClass()->GetName());
-		return;
-	}
-
-	CameraDefaultsParameters = PlayerController->GetCameraDefaultsParameters();
-	if (!ensure(CameraDefaultsParameters))
-	{
-		UE_LOG(LogG2I, Error, TEXT("%s can not return camera defaults parameters in %s in %s"),
-			*PlayerController->GetName(), *GetName(), *Owner->GetActorNameOrLabel());
 		return;
 	}
 }
@@ -526,12 +517,18 @@ void UG2ICharacterMovementComponent::SetMovementWithThirdPersonCamera(const EG2I
 }
 
 void UG2ICharacterMovementComponent::SetMovementWithFixedCamera(const EG2ICameraBlendState CurrentBlendState,
-	const UCameraComponent* NewCamera)
+	const UCameraComponent* NewCamera, const float DelayMovementTime)
 {
 	if (CurrentBlendState == EG2ICameraBlendState::Start)
 	{
 		bCanRotationTowardsCamera = false;
 		DisableRotationTowardsCamera();
+
+		if (DelayMovementTime <= 0)
+		{
+			ResetCameraPendingYawRotation(NewCamera);
+			return;
+		}
 		
 		if (!ensure(World))
 		{
@@ -539,21 +536,12 @@ void UG2ICharacterMovementComponent::SetMovementWithFixedCamera(const EG2ICamera
 			ResetCameraPendingYawRotation(NewCamera);
 			return;
 		}
-
 		World->GetTimerManager().ClearTimer(TimerBeforeDisableRotationTowardsCamera);
-		
-		if (!ensure(CameraDefaultsParameters))
-		{
-			UE_LOG(LogG2I, Error, TEXT("%s: Couldn't find %s"), *GetName(),
-				*UG2ICameraDefaultsParameters::StaticClass()->GetName());
-			ResetCameraPendingYawRotation(NewCamera);
-			return;
-		}
 		
 		const FTimerDelegate Delegate = FTimerDelegate::CreateUObject(
 			this, &ThisClass::ResetCameraPendingYawRotation, NewCamera);
-		World->GetTimerManager().SetTimer(TimerBeforeDisableRotationTowardsCamera, Delegate,
-			CameraDefaultsParameters->PendingTimeAfterSwitchingToControlCharacter, false);
+		World->GetTimerManager().SetTimer(
+			TimerBeforeDisableRotationTowardsCamera, Delegate, DelayMovementTime, false);
 	}
 }
 

--- a/Source/G2I/Private/Components/G2ICharacterMovementComponent.cpp
+++ b/Source/G2I/Private/Components/G2ICharacterMovementComponent.cpp
@@ -45,11 +45,11 @@ void UG2ICharacterMovementComponent::SetupDefaults()
 		UE_LOG(LogG2I, Error, TEXT("World doesn't exist in %s"), *GetName());
 		return;
 	}
-	AG2IPlayerController *PlayerController = Cast<AG2IPlayerController>(World->GetFirstPlayerController());
+	PlayerController = Cast<AG2IPlayerController>(World->GetFirstPlayerController());
 	if (!ensure(PlayerController))
 	{
-		UE_LOG(LogG2I, Error, TEXT("%s doesn't exist in %s in %s"),
-			*AG2IPlayerController::StaticClass()->GetName(), *GetName(), *Owner->GetActorNameOrLabel());
+		UE_LOG(LogG2I, Error, TEXT("%s: Couldn't find %s"),
+			*GetName(), *AG2IPlayerController::StaticClass()->GetName());
 		return;
 	}
 
@@ -179,7 +179,7 @@ void UG2ICharacterMovementComponent::ToggleCrouchAction_Implementation()
 	}
 }
 
-void UG2ICharacterMovementComponent::SetCanPassThroughObject(bool Value)
+void UG2ICharacterMovementComponent::SetCanPassThroughObject(const bool Value)
 {
 	bCanPassThroughObject = Value;
 }
@@ -227,7 +227,7 @@ void UG2ICharacterMovementComponent::ToggleRotation() {
 	bOrientRotationToMovement = !bOrientRotationToMovement;
 }
 
-void UG2ICharacterMovementComponent::ToggleSlow(float SpeedChange)
+void UG2ICharacterMovementComponent::ToggleSlow(const float SpeedChange)
 {
 	if (SpeedChange < 0) {
 		UE_LOG(LogG2I, Log, TEXT("Speed can't be negative"));
@@ -249,7 +249,7 @@ void UG2ICharacterMovementComponent::ToggleSlow(float SpeedChange)
 	}
 }
 
-void UG2ICharacterMovementComponent::HandleMovingInteraction(float SpeedChange)
+void UG2ICharacterMovementComponent::HandleMovingInteraction(const float SpeedChange)
 {
 	ToggleCrouch();
 	ToggleJump();
@@ -260,13 +260,6 @@ void UG2ICharacterMovementComponent::BindingToDelegates()
 {
 	BindingOwnerComponentsDelegates();
 	
-	if (!ensure(World))
-	{
-		UE_LOG(LogG2I, Error, TEXT("World doesn't exist in %s"), *GetName());
-		return;
-	}
-
-	const APlayerController *PlayerController = World->GetFirstPlayerController();
 	if (!ensure(PlayerController))
 	{
 		UE_LOG(LogG2I, Error, TEXT("PlayerController doesn't exist in %s"), *GetName());
@@ -306,7 +299,8 @@ void UG2ICharacterMovementComponent::BindingOwnerComponentsDelegates()
 
 	if (UG2ICameraControllerComponent *CameraControllerComponent = Owner->FindComponentByClass<UG2ICameraControllerComponent>())
 	{
-		CameraControllerComponent->OnSetCameraTypeDelegate.AddDynamic(this, &ThisClass::SetAbilityRotationTowardsCamera);
+		CameraControllerComponent->OnSetThirdPersonCameraTypeDelegate.AddDynamic(this, &ThisClass::SetMovementWithThirdPersonCamera);
+		CameraControllerComponent->OnSetFixedCameraTypeDelegate.AddDynamic(this, &ThisClass::SetMovementWithFixedCamera);
 		CameraControllerComponent->OnThirdPersonCameraYawRotationDelegate.AddDynamic(this,
 			&ThisClass::UG2ICharacterMovementComponent::SetCameraPendingYawRotation);
 	}
@@ -505,11 +499,23 @@ void UG2ICharacterMovementComponent::DisableRotationTowardsCamera()
 	Owner->bUseControllerRotationRoll = false;
 }
 
-void UG2ICharacterMovementComponent::SetAbilityRotationTowardsCamera(
-	EG2ICameraTypeEnum CurrentCameraType, EG2ICameraBlendState CurrentBlendState)
+void UG2ICharacterMovementComponent::SetMovementWithThirdPersonCamera(const EG2ICameraBlendState CurrentBlendState,
+	const UCameraComponent* NewCamera)
 {
-	if (CurrentCameraType == EG2ICameraTypeEnum::ThirdPersonCamera && CurrentBlendState == EG2ICameraBlendState::Finish)
+	switch (CurrentBlendState)
 	{
+	case EG2ICameraBlendState::Start:
+		if (!ensure(World))
+		{
+			UE_LOG(LogG2I, Error, TEXT("%s: Couldn't find %s"), *GetName(), *UWorld::StaticClass()->GetName());
+		}
+		else
+		{
+			World->GetTimerManager().ClearTimer(TimerBeforeDisableRotationTowardsCamera);
+		}
+		ResetCameraPendingYawRotation(NewCamera);
+		return;
+	case EG2ICameraBlendState::Finish:
 		bCanRotationTowardsCamera = true;
 		if (bWantsRotationTowardsCamera)
 		{
@@ -517,35 +523,56 @@ void UG2ICharacterMovementComponent::SetAbilityRotationTowardsCamera(
 		}
 		return;
 	}
-	
-	if (CurrentCameraType == EG2ICameraTypeEnum::FixedCamera && CurrentBlendState == EG2ICameraBlendState::Start)
+}
+
+void UG2ICharacterMovementComponent::SetMovementWithFixedCamera(const EG2ICameraBlendState CurrentBlendState,
+	const UCameraComponent* NewCamera)
+{
+	if (CurrentBlendState == EG2ICameraBlendState::Start)
 	{
 		bCanRotationTowardsCamera = false;
 		DisableRotationTowardsCamera();
 		
 		if (!ensure(World))
 		{
-			UE_LOG(LogG2I, Error, TEXT("World doesn't exist in %s"), *GetName());
-			ResetCameraPendingYawRotation();
+			UE_LOG(LogG2I, Error, TEXT("%s: Couldn't find %s"), *GetName(), *UWorld::StaticClass()->GetName());
+			ResetCameraPendingYawRotation(NewCamera);
 			return;
 		}
+
+		World->GetTimerManager().ClearTimer(TimerBeforeDisableRotationTowardsCamera);
+		
 		if (!ensure(CameraDefaultsParameters))
 		{
-			UE_LOG(LogG2I, Error, TEXT("%s isn't initialized in %s in %s"),
-				*UG2ICameraDefaultsParameters::StaticClass()->GetName(), *GetName(), *Owner->GetActorNameOrLabel());
-			ResetCameraPendingYawRotation();
+			UE_LOG(LogG2I, Error, TEXT("%s: Couldn't find %s"), *GetName(),
+				*UG2ICameraDefaultsParameters::StaticClass()->GetName());
+			ResetCameraPendingYawRotation(NewCamera);
 			return;
 		}
-		World->GetTimerManager().ClearTimer(TimerBeforeDisableRotationTowardsCamera);
-		World->GetTimerManager().SetTimer(TimerBeforeDisableRotationTowardsCamera,
-			this, &ThisClass::ResetCameraPendingYawRotation,
+		
+		const FTimerDelegate Delegate = FTimerDelegate::CreateUObject(
+			this, &ThisClass::ResetCameraPendingYawRotation, NewCamera);
+		World->GetTimerManager().SetTimer(TimerBeforeDisableRotationTowardsCamera, Delegate,
 			CameraDefaultsParameters->PendingTimeAfterSwitchingToControlCharacter, false);
 	}
 }
 
-void UG2ICharacterMovementComponent::ResetCameraPendingYawRotation()
+void UG2ICharacterMovementComponent::ResetCameraPendingYawRotation(const UCameraComponent* NewCamera)
 {
 	CameraPendingYawRotation = 0.;
+	
+	if (!ensure(NewCamera))
+	{
+		UE_LOG(LogG2I, Warning, TEXT("%s: Attempt to set null new camera"), *GetName());
+		return;
+	}
+	if (!ensure(PlayerController))
+	{
+		UE_LOG(LogG2I, Error, TEXT("%s: Couldn't find %s"),
+			*GetName(), *AG2IPlayerController::StaticClass()->GetName());
+		return;
+	}
+	PlayerController->SetRotationTowardsCamera(*NewCamera);
 }
 
 void UG2ICharacterMovementComponent::SetCameraPendingYawRotation(const double YawValue)

--- a/Source/G2I/Private/Components/SteamGlove/G2IAimingComponent.cpp
+++ b/Source/G2I/Private/Components/SteamGlove/G2IAimingComponent.cpp
@@ -118,7 +118,8 @@ void UG2IAimingComponent::BindDelegates()
 	
 	if (UG2ICameraControllerComponent *CameraControllerComponent = Owner->FindComponentByClass<UG2ICameraControllerComponent>())
 	{
-		CameraControllerComponent->OnSetCameraTypeDelegate.AddDynamic(this, &ThisClass::SetAbilityAiming);
+		CameraControllerComponent->OnSetThirdPersonCameraTypeDelegate.AddDynamic(this, &ThisClass::EnableAbilityAiming);
+		CameraControllerComponent->OnSetFixedCameraTypeDelegate.AddDynamic(this, &ThisClass::DisableAbilityAiming);
 	}
 
 	if (UG2ISteamShotComponent *SteamShotComponent = Owner->FindComponentByClass<UG2ISteamShotComponent>())
@@ -186,9 +187,9 @@ UActorComponent *UG2IAimingComponent::GetCurrentComponentUsingAim_Implementation
 	return nullptr;
 }
 
-void UG2IAimingComponent::SetAbilityAiming(EG2ICameraTypeEnum CurrentCameraType, EG2ICameraBlendState CurrentBlendState)
+void UG2IAimingComponent::EnableAbilityAiming(const EG2ICameraBlendState CurrentBlendState, const UCameraComponent* NewCamera)
 {
-	if (CurrentCameraType == EG2ICameraTypeEnum::ThirdPersonCamera && CurrentBlendState == EG2ICameraBlendState::Finish)
+	if (CurrentBlendState == EG2ICameraBlendState::Finish)
 	{
 		bCanAiming = true;
 		if (bWantsAiming)
@@ -197,8 +198,12 @@ void UG2IAimingComponent::SetAbilityAiming(EG2ICameraTypeEnum CurrentCameraType,
 		}
 		return;
 	}
+}
 
-	if (CurrentCameraType == EG2ICameraTypeEnum::FixedCamera && CurrentBlendState == EG2ICameraBlendState::Start)
+void UG2IAimingComponent::DisableAbilityAiming(const EG2ICameraBlendState CurrentBlendState,
+	const UCameraComponent* NewCamera)
+{
+	if (CurrentBlendState == EG2ICameraBlendState::Start)
 	{
 		bCanAiming = false;
 		if (bIsAiming)
@@ -215,7 +220,7 @@ void UG2IAimingComponent::SetAimDistance(const float NewAimDistance)
 	CurrentAimDistance = NewAimDistance;
 }
 
-void UG2IAimingComponent::SetPendingAimType(EG2IAimType NewAimType)
+void UG2IAimingComponent::SetPendingAimType(const EG2IAimType NewAimType)
 {
 	bAimViewIsPending = true;
 
@@ -301,7 +306,7 @@ void UG2IAimingComponent::DetectAimLineHitInfo()
 	}
 }
 
-void UG2IAimingComponent::OutlineController(const AActor* ActorToChangeOutline, bool bOutlineMode)
+void UG2IAimingComponent::OutlineController(const AActor* ActorToChangeOutline, const bool bOutlineMode) const
 {
 	TArray<UStaticMeshComponent*> OutlineMeshes;
 	if (ActorToChangeOutline && ActorToChangeOutline->Implements<UG2ITraceableObectInterface>())
@@ -309,7 +314,7 @@ void UG2IAimingComponent::OutlineController(const AActor* ActorToChangeOutline, 
 		ActorToChangeOutline->GetComponents<UStaticMeshComponent>(OutlineMeshes);
 	}
 
-	for (auto OutlineMesh : OutlineMeshes)
+	for (const auto OutlineMesh : OutlineMeshes)
 	{
 		if (!OutlineMesh)
 		{

--- a/Source/G2I/Private/Components/SteamGlove/G2IAimingComponent.cpp
+++ b/Source/G2I/Private/Components/SteamGlove/G2IAimingComponent.cpp
@@ -201,7 +201,7 @@ void UG2IAimingComponent::EnableAbilityAiming(const EG2ICameraBlendState Current
 }
 
 void UG2IAimingComponent::DisableAbilityAiming(const EG2ICameraBlendState CurrentBlendState,
-	const UCameraComponent* NewCamera)
+	const UCameraComponent* NewCamera, const float DelayMovementTime)
 {
 	if (CurrentBlendState == EG2ICameraBlendState::Start)
 	{

--- a/Source/G2I/Public/Components/Camera/G2ICameraControllerComponent.h
+++ b/Source/G2I/Public/Components/Camera/G2ICameraControllerComponent.h
@@ -9,11 +9,11 @@
 class UG2ICameraDefaultsParameters;
 class AG2IPlayerController;
 class UCameraComponent;
-class UG2IFixedCamerasComponent;
-class UG2IThirdPersonCameraComponent;
 
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FSetCameraTypeDelegate, EG2ICameraTypeEnum, CurrentCameraType,
-	EG2ICameraBlendState, CurrentBlendState);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FSetThirdPersonCameraTypeDelegate,
+	EG2ICameraBlendState, CurrentBlendState, const UCameraComponent *, NewCamera);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FSetFixedCameraTypeDelegate,
+	EG2ICameraBlendState, CurrentBlendState, const UCameraComponent *, NewCamera);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FThirdPersonCameraYawRotationDelegate, double, OldCameraYawRotation);
 
 UCLASS(ClassGroup=(Camera), meta=(BlueprintSpawnableComponent))
@@ -24,7 +24,10 @@ class G2I_API UG2ICameraControllerComponent : public UActorComponent, public IG2
 public:
 
 	UPROPERTY(BlueprintAssignable)
-	FSetCameraTypeDelegate OnSetCameraTypeDelegate;
+	FSetThirdPersonCameraTypeDelegate OnSetThirdPersonCameraTypeDelegate;
+	
+	UPROPERTY(BlueprintAssignable)
+	FSetFixedCameraTypeDelegate OnSetFixedCameraTypeDelegate;
 
 	UPROPERTY(BlueprintAssignable)
 	FThirdPersonCameraYawRotationDelegate OnThirdPersonCameraYawRotationDelegate;
@@ -52,16 +55,13 @@ private:
 protected:
 	
 	UG2ICameraControllerComponent();
-	
-	virtual void BeginPlay() override;
-	virtual void InitializeComponent() override;
 
 	void PreInitializationDefaults();
 
-	virtual void TickComponent(float DeltaTime, ELevelTick TickType,
-		FActorComponentTickFunction* ThisTickFunction) override;
-
 public:
+	
+	virtual void BeginPlay() override;
+	virtual void InitializeComponent() override;
 	
 	// Interface methods
 	UFUNCTION(BlueprintCallable, Category="Setup")
@@ -84,7 +84,7 @@ private:
 	UFUNCTION()
 	void BroadcastCameraTypeAfterBlendFinish();
 
-	void BroadcastCameraTypeAtBlendStart();
+	void BroadcastCameraTypeAtBlendStart(const UCameraComponent& NewCamera) const;
 
 	bool IsOwnerControllable() const;
 

--- a/Source/G2I/Public/Components/Camera/G2ICameraControllerComponent.h
+++ b/Source/G2I/Public/Components/Camera/G2ICameraControllerComponent.h
@@ -12,8 +12,8 @@ class UCameraComponent;
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FSetThirdPersonCameraTypeDelegate,
 	EG2ICameraBlendState, CurrentBlendState, const UCameraComponent *, NewCamera);
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FSetFixedCameraTypeDelegate,
-	EG2ICameraBlendState, CurrentBlendState, const UCameraComponent *, NewCamera);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams(FSetFixedCameraTypeDelegate,
+	EG2ICameraBlendState, CurrentBlendState, const UCameraComponent *, NewCamera, float, DelayMovementTime);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FThirdPersonCameraYawRotationDelegate, double, OldCameraYawRotation);
 
 UCLASS(ClassGroup=(Camera), meta=(BlueprintSpawnableComponent))
@@ -50,7 +50,9 @@ private:
 
 	EG2ICameraTypeEnum CurrentCameraType = EG2ICameraTypeEnum::FixedCamera;
 
-	float OldCameraYawRotation = 0.;
+	double OldCameraYawRotation = 0.;
+	
+	float DelayMovementTime = 0.f;
 
 protected:
 	
@@ -84,7 +86,7 @@ private:
 	UFUNCTION()
 	void BroadcastCameraTypeAfterBlendFinish();
 
-	void BroadcastCameraTypeAtBlendStart(const UCameraComponent& NewCamera) const;
+	void BroadcastCameraTypeAtBlendStart(const UCameraComponent& NewCamera);
 
 	bool IsOwnerControllable() const;
 
@@ -106,5 +108,7 @@ private:
 	void SetThirdPersonCameraYawRotation();
 
 	void SetCurrentCameraIndex(int32 NewCameraIndex);
+	
+	void SetDefaultDelayMovementTime();
 	
 };

--- a/Source/G2I/Public/Components/G2ICharacterMovementComponent.h
+++ b/Source/G2I/Public/Components/G2ICharacterMovementComponent.h
@@ -8,10 +8,7 @@
 #include "G2ICharacterMovementComponent.generated.h"
 
 class AG2IPlayerController;
-class UG2ICameraDefaultsParameters;
 enum class EG2ICameraBlendState : uint8;
-enum class EG2ICameraTypeEnum : uint8;
-class UCharacterMovementComponent;
 
 UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
 class G2I_API UG2ICharacterMovementComponent : public UCharacterMovementComponent, public IG2IMovementInputInterface
@@ -25,9 +22,6 @@ private:
 
 	UPROPERTY()
 	TObjectPtr<UWorld> World;
-
-	UPROPERTY()
-	TObjectPtr<UG2ICameraDefaultsParameters> CameraDefaultsParameters;
 	
 	UPROPERTY()
 	TObjectPtr<AG2IPlayerController> PlayerController;
@@ -133,7 +127,8 @@ protected:
 	void SetMovementWithThirdPersonCamera(EG2ICameraBlendState CurrentBlendState, const UCameraComponent* NewCamera);
 	
 	UFUNCTION()
-	void SetMovementWithFixedCamera(EG2ICameraBlendState CurrentBlendState, const UCameraComponent* NewCamera);
+	void SetMovementWithFixedCamera(EG2ICameraBlendState CurrentBlendState, const UCameraComponent* NewCamera,
+		float DelayMovementTime);
 	
 	void ResetCameraPendingYawRotation(const UCameraComponent* NewCamera);
 

--- a/Source/G2I/Public/Components/G2ICharacterMovementComponent.h
+++ b/Source/G2I/Public/Components/G2ICharacterMovementComponent.h
@@ -2,10 +2,12 @@
 
 #include "CoreMinimal.h"
 #include "G2IMovementInputInterface.h"
+#include "Camera/CameraComponent.h"
 #include "Components/ActorComponent.h"
 #include "GameFramework/CharacterMovementComponent.h"
 #include "G2ICharacterMovementComponent.generated.h"
 
+class AG2IPlayerController;
 class UG2ICameraDefaultsParameters;
 enum class EG2ICameraBlendState : uint8;
 enum class EG2ICameraTypeEnum : uint8;
@@ -26,6 +28,9 @@ private:
 
 	UPROPERTY()
 	TObjectPtr<UG2ICameraDefaultsParameters> CameraDefaultsParameters;
+	
+	UPROPERTY()
+	TObjectPtr<AG2IPlayerController> PlayerController;
 	
 protected:
 	DECLARE_DYNAMIC_MULTICAST_DELEGATE(FJumpingDelegate);
@@ -59,11 +64,11 @@ protected:
 	
 	UG2ICharacterMovementComponent();
 
+public:
+	
 	virtual void BeginPlay() override;
 
 	virtual void OnRegister() override;
-
-public:
 
 	// Interface methods
 	UFUNCTION(BlueprintCallable, Category="Input")
@@ -125,9 +130,12 @@ protected:
 	void DisableRotationTowardsCamera();
 
 	UFUNCTION()
-	void SetAbilityRotationTowardsCamera(EG2ICameraTypeEnum CurrentCameraType, EG2ICameraBlendState CurrentBlendState);
+	void SetMovementWithThirdPersonCamera(EG2ICameraBlendState CurrentBlendState, const UCameraComponent* NewCamera);
 	
-	void ResetCameraPendingYawRotation();
+	UFUNCTION()
+	void SetMovementWithFixedCamera(EG2ICameraBlendState CurrentBlendState, const UCameraComponent* NewCamera);
+	
+	void ResetCameraPendingYawRotation(const UCameraComponent* NewCamera);
 
 	UFUNCTION()
 	void SetCameraPendingYawRotation(double YawValue);

--- a/Source/G2I/Public/Components/SteamGlove/G2IAimingComponent.h
+++ b/Source/G2I/Public/Components/SteamGlove/G2IAimingComponent.h
@@ -104,7 +104,8 @@ protected:
 	void EnableAbilityAiming(EG2ICameraBlendState CurrentBlendState,const UCameraComponent* NewCamera);
 	
 	UFUNCTION()
-	void DisableAbilityAiming(EG2ICameraBlendState CurrentBlendState, const UCameraComponent* NewCamera);
+	void DisableAbilityAiming(EG2ICameraBlendState CurrentBlendState, const UCameraComponent* NewCamera,
+		float DelayMovementTime);
 	
 	UFUNCTION()
 	void SetAimDistance(const float NewAimDistance);

--- a/Source/G2I/Public/Components/SteamGlove/G2IAimingComponent.h
+++ b/Source/G2I/Public/Components/SteamGlove/G2IAimingComponent.h
@@ -5,12 +5,12 @@
 #include "G2IHitInfo.h"
 #include "Components/ActorComponent.h"
 #include "G2IAimTypeEnum.h"
+#include "Camera/CameraComponent.h"
 #include "G2IAimingComponent.generated.h"
 
 enum class EG2ICameraBlendState : uint8;
 class UG2IUIManager;
 enum class EG2IAimType : uint8;
-enum class EG2ICameraTypeEnum : uint8;
 class UG2IAimingWidget;
 class AG2IPlayerController;
 
@@ -101,7 +101,10 @@ public:
 protected:
 
 	UFUNCTION()
-	void SetAbilityAiming(EG2ICameraTypeEnum CurrentCameraType, EG2ICameraBlendState CurrentBlendState);
+	void EnableAbilityAiming(EG2ICameraBlendState CurrentBlendState,const UCameraComponent* NewCamera);
+	
+	UFUNCTION()
+	void DisableAbilityAiming(EG2ICameraBlendState CurrentBlendState, const UCameraComponent* NewCamera);
 	
 	UFUNCTION()
 	void SetAimDistance(const float NewAimDistance);
@@ -121,6 +124,6 @@ private:
 
 	void SetAimType(const AActor* TargetActor);
 	
-	void OutlineController(const AActor* ActorToChangeOutline, bool bOutlineMode);
+	void OutlineController(const AActor* ActorToChangeOutline, bool bOutlineMode) const;
 
 };


### PR DESCRIPTION
Задержка переключения контроллера управления при переключении на фиксированную камеру.
Раньше было только с переключения от камеры третьего лица на фиксированную, теперь при переключении любой камеры на фиксированную.

Когда будет настройка уровня надо поменять, кажется, получше время задержки (уменьшить). И возможно, обдумать ещё расположение фикс.камер 

Есть ещё баг, который в другом пр решу. В начале уровня, если установлена фиксированная камера, то есть задержка с переключения из начальной камеры.
Временное решение: запуск кат-сцены, или повернуть фиксированную камеру в направлении взгляда персонажа, или начинать уровень с камеры от третьего лица.
Вот issue: https://github.com/PosAlina/G2I-Game/issues/491

*Ещё в файлах, которых касалась варнинги райдера поправила чуток


Собственно, что в коде происходит:
1. При переключении на камеру вызывается OnSetThirdPersonCameraTypeDelegate или OnSetFixedCameraTypeDelegate, в зависимости от типа новой камеры. Вызываются дважды: в начале перехода (бленда) и в конце перехода (бленда). Раньше был один общий делегат

2. Уже был функционал:
-При переключении на фиксированную камеру отключается поворот камеры и через время CameraDefaultsParameters->PendingTimeAfterSwitchingToControlCharacter перемещение персонажа переключается на фиксированную камеру.
Добавила:
- Контроллер поворачивается теперь для новой камеры не сразу же, а через тот же таймер CameraDefaultsParameters->PendingTimeAfterSwitchingToControlCharacter. До этого если уже была фиксированная камера, то управление контроллера остаётся на время зависимо от этой старой камеры.

3.Уже был функционал:
-При переключении на камеру от третьего лица в конце перехода становится доступен поворот камеры.
Добавила:
-Сделала, чтоб в начале перехода на камеру от третьего лица сбрасывалась вся логика, связанная с фиксированными камерами

4. AimingComponent - переписала логику, завязанную на общий делегат, разделив её на два делегата. - В логике ничего не менялось

5. Убрала Tick из CameraComponent - он не нужен в случае, когда у нас нет переключения камер.