### PR TITLE
feat: Кат-сцена перезапускается после выхода в ней в меню и нажатия новой игры

### DIFF
--- a/Source/G2I/Private/UI/G2IUIDisplayManager.cpp
+++ b/Source/G2I/Private/UI/G2IUIDisplayManager.cpp
@@ -308,6 +308,7 @@ void UG2IUIDisplayManager::CloseWidget(const EG2IWidgetNames WidgetName)
 	{
 		if (UG2IUserWidget *Widget = WidgetInfo->Widget)
 		{
+			Widget->CloseWidget();
 			Widget->RemoveFromParent();
 
 			if (TSet<EG2IWidgetNames> *ActiveWidgetsNamesByType = AllActiveWidgetsNames.Find(WidgetInfo->Type))
@@ -367,6 +368,8 @@ void UG2IUIDisplayManager::CloseAllActiveWidgets()
 	{
 		CloseActiveWidgetsByType(ActiveWidgetsType);
 	}
+	
+	ActiveWidgetComponentsID.Empty();
 }
 
 void UG2IUIDisplayManager::CloseActiveWidgetsByType(const EG2IWidgetTypes WidgetsType)
@@ -379,6 +382,7 @@ void UG2IUIDisplayManager::CloseActiveWidgetsByType(const EG2IWidgetTypes Widget
 			{
 				if (UG2IUserWidget *Widget = WidgetInfo->Widget)
 				{
+					Widget->CloseWidget();
 					Widget->RemoveFromParent();
 				}
 			}

--- a/Source/G2I/Private/UI/G2IUIManager.cpp
+++ b/Source/G2I/Private/UI/G2IUIManager.cpp
@@ -202,7 +202,7 @@ void UG2IUIManager::CloseCutScene(const EG2IWidgetNames WidgetName) const
 	OpenHUD();
 }
 
-void UG2IUIManager::CloseLevelUI()
+void UG2IUIManager::CloseLevelUI() const
 {
 	CloseAllWidgets();
 	ShowAllWidgets(); // For visibility widgets in next level

--- a/Source/G2I/Private/UI/Widgets/CutScenes/G2ICutSceneWidget.cpp
+++ b/Source/G2I/Private/UI/Widgets/CutScenes/G2ICutSceneWidget.cpp
@@ -49,7 +49,13 @@ void UG2ICutSceneWidget::NativeTick(const FGeometry& MyGeometry, float InDeltaTi
 		SetSkipPercent(NewPercent);
 		if (NewPercent == 1.f)
 		{
-			CloseWidget();
+			if (!ensure(UIManager))
+			{
+				UE_LOG(LogG2I, Error, TEXT("%s: Couldn't find %s"), *GetName(),
+					*UG2IUIManager::StaticClass()->GetName());
+				return;
+			}
+			UIManager->CloseCutScene(CurrentWidgetName);
 		}
 	}
 }
@@ -107,7 +113,13 @@ FReply UG2ICutSceneWidget::NativeOnMouseButtonDown(const FGeometry& InGeometry, 
 		if (!ensure(SheetsSwitcher))
 		{
 			UE_LOG(LogG2I, Error, TEXT("%s: Couldn't find SheetsSwitcher"), *GetName());
-			CloseWidget();
+			if (!ensure(UIManager))
+			{
+				UE_LOG(LogG2I, Error, TEXT("%s: Couldn't find %s"), *GetName(),
+					*UG2IUIManager::StaticClass()->GetName());
+				return Reply;
+			}
+			UIManager->CloseCutScene(CurrentWidgetName);
 			return Reply;
 		}
 		
@@ -125,7 +137,13 @@ FReply UG2ICutSceneWidget::NativeOnMouseButtonDown(const FGeometry& InGeometry, 
 			return Reply;
 		}
 
-		CloseWidget();
+		if (!ensure(UIManager))
+		{
+			UE_LOG(LogG2I, Error, TEXT("%s: Couldn't find %s"), *GetName(),
+				*UG2IUIManager::StaticClass()->GetName());
+			return Reply;
+		}
+		UIManager->CloseCutScene(CurrentWidgetName);
 	}
 	
 	return Reply;
@@ -178,15 +196,11 @@ float UG2ICutSceneWidget::GetSkipPercent() const
 
 void UG2ICutSceneWidget::CloseWidget()
 {
-	if (!ensure(UIManager))
-	{
-		UE_LOG(LogG2I, Error, TEXT("%s: Couldn't find %s"), *GetName(),
-			*UG2IUIManager::StaticClass()->GetName());
-		return;
-	}
-	UIManager->CloseCutScene(CurrentWidgetName);
+	Super::CloseWidget();
+	
 	bIsSkipPressed = false;
 	SetSkipPercent(0.f);
+	bIsEnabled = true;
 	
 	if (!ensure(SheetsSwitcher))
 	{

--- a/Source/G2I/Private/UI/Widgets/Menu/Options/G2IOptionsWidget.cpp
+++ b/Source/G2I/Private/UI/Widgets/Menu/Options/G2IOptionsWidget.cpp
@@ -5,6 +5,19 @@
 #include "Components/Button.h"
 #include "Components/WidgetSwitcher.h"
 
+void UG2IOptionsWidget::CloseWidget()
+{
+	Super::CloseWidget();
+	
+	if (!ensure(UIManager))
+	{
+		UE_LOG(LogG2I, Error, TEXT("%s: Couldn't find %s"), *GetName(),
+			*UG2IUIManager::StaticClass()->GetName());
+		return;
+	}
+	UIManager->CancelAllUnAppliedOptions(OptionsSubWidgetSwitcher);
+}
+
 void UG2IOptionsWidget::InitializeAfterManagerLoading()
 {
 	Super::InitializeAfterManagerLoading();
@@ -109,14 +122,6 @@ void UG2IOptionsWidget::OnBackButtonClicked()
 	{
 		UE_LOG(LogG2I, Warning, TEXT("Back function is undefined in %s"), *GetName());
 	}
-	
-	if (!ensure(UIManager))
-	{
-		UE_LOG(LogG2I, Error, TEXT("%s: Couldn't find %s"), *GetName(),
-			*UG2IUIManager::StaticClass()->GetName());
-		return;
-	}
-	UIManager->CancelAllUnAppliedOptions(OptionsSubWidgetSwitcher);
 	UIManager->CloseWidget(EG2IWidgetNames::Options);
 }
 

--- a/Source/G2I/Public/UI/G2IUIManager.h
+++ b/Source/G2I/Public/UI/G2IUIManager.h
@@ -71,7 +71,7 @@ protected:
 	void InitializeNewLevelUI() const;
 	
 	UFUNCTION()
-	void CloseLevelUI();
+	void CloseLevelUI() const;
 
 public:
 

--- a/Source/G2I/Public/UI/Widgets/CutScenes/G2ICutSceneWidget.h
+++ b/Source/G2I/Public/UI/Widgets/CutScenes/G2ICutSceneWidget.h
@@ -53,6 +53,10 @@ private:
 
 	UPROPERTY()
 	TObjectPtr<UMaterialInstanceDynamic> SkipBarMaterialInstance;
+	
+public:
+	
+	virtual void CloseWidget() override;
 
 protected:
 
@@ -71,7 +75,5 @@ protected:
 	void SetSkipPercent(float Percent) const;
 
 	float GetSkipPercent() const;
-
-	void CloseWidget();
 	
 };

--- a/Source/G2I/Public/UI/Widgets/G2IUserWidget.h
+++ b/Source/G2I/Public/UI/Widgets/G2IUserWidget.h
@@ -29,6 +29,10 @@ protected:
 
 	UPROPERTY()
 	TObjectPtr<UG2IGameInstance> GameInstance;
+	
+public:
+	
+	virtual void CloseWidget() {}
 
 protected:
 

--- a/Source/G2I/Public/UI/Widgets/Menu/Options/G2IOptionsWidget.h
+++ b/Source/G2I/Public/UI/Widgets/Menu/Options/G2IOptionsWidget.h
@@ -44,6 +44,8 @@ public:
 public:
 
 	TFunction<void()> OnBack;
+	
+	virtual void CloseWidget() override;
 
 protected:
 


### PR DESCRIPTION
Сценарий:
Кат-сцена запускается.
Во время кат-сцены игрок вызывает паузу.
Из паузы игрок переходит в главное меню.
Игрок нажимает Новая игра.
ФИКС: Кат-сцена теперь корректно перезапускается с рабочим инпутом