### PR TITLE
fix: change order in condition checks in fly function

### DIFF
--- a/Source/G2I/Private/Controls/G2IPlayerController.cpp
+++ b/Source/G2I/Private/Controls/G2IPlayerController.cpp
@@ -755,7 +755,7 @@ void AG2IPlayerController::Fly(const int Direction) const
 		return;
 	}
 	
-	if (Direction == 1 && IG2IFlightInterface::Execute_Fly(FlightComponent, Direction))
+	if (IG2IFlightInterface::Execute_Fly(FlightComponent, Direction) && Direction == 1)
 	{
 		OnFlyUpDelegate.Broadcast();
 	}


### PR DESCRIPTION
Close #607
Баг был только с опускание, пофиксила.
Чтобы дочка поднималась, нужно в компоненте полета в поле Flight Height указать максимальную высоту на локации (в ангаре это в районе 2700 по z, ну или меньше можно, смотря как по дизайну нужно)
<img width="409" height="178" alt="image" src="https://github.com/user-attachments/assets/c9168735-65f7-496d-885c-db31a0dc8e59" />
