### PR TITLE
fix: Не вызывался BeginPlay у VerticalMovementComponent после загрузки уровня

### DIFF
--- a/Source/G2I/Private/Components/G2IGrabberComponent.cpp
+++ b/Source/G2I/Private/Components/G2IGrabberComponent.cpp
@@ -37,6 +37,38 @@ UG2IGrabberComponent::UG2IGrabberComponent()
 	}
 }
 
+void UG2IGrabberComponent::OnRegister()
+{
+	Super::OnRegister();
+	
+	if (!ensure(VerticalMovementComp))
+	{
+		UE_LOG(LogG2I, Error, TEXT("%s: Couldn't find VerticalMovementComponent"), *GetName());
+	}
+	else
+	{
+		VerticalMovementComp->RegisterComponent();
+	}
+	
+	if (!ensure(PhysicsHandleComp))
+	{
+		UE_LOG(LogG2I, Error, TEXT("%s: Couldn't find PhysicsHandleComponent"), *GetName());
+	}
+	else
+	{
+		PhysicsHandleComp->RegisterComponent();
+	}
+	
+	if (!ensure(SoundComp))
+	{
+		UE_LOG(LogG2I, Error, TEXT("%s: Couldn't find SoundComp"), *GetName());
+	}
+	else
+	{
+		SoundComp->RegisterComponent();
+	}
+}
+
 void UG2IGrabberComponent::PlayHookAnimation(UAnimSequence* Animation)
 {
 	if (!ensure(SkeletalMeshComp) || !ensure(Animation)) {

--- a/Source/G2I/Public/Components/G2IGrabberComponent.h
+++ b/Source/G2I/Public/Components/G2IGrabberComponent.h
@@ -46,6 +46,8 @@ private:
 	int32 GrabbingSoundId = -1;
 public:	
 	UG2IGrabberComponent();
+	
+	virtual void OnRegister() override;
 
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Sound")
 	TObjectPtr<UG2ISoundComponent> SoundComp;


### PR DESCRIPTION
В анриле компоненты могут быть только у акторов, но не актор компонент.
Если хочется задать компоненты внутри компонент актора, то надо как-то оповещать актора об этих компонентах, он не всегда может увидеть их.

Короч есть актор MovindByGaerWithSpline (как-то так, ну или где была добавлена граббер компонента).
В него добавляется UG2IGrabberComponent (в блюпринте добавилась).
В ней задана UG2IVerticalMovementComponent.

И в анриле могут быть проблемы с тем, что актор автоматически может не увидеть UG2IVerticalMovementComponent, если она не прикреплена к нему. Надо читать, какие у этого могут быть последствия, я не скажу сходу (если найдёте инфу об этом, то скиньте и мне, пожалуйста, интересно будет подуглубиться).
В конкретно данном случае, актор не зарегестрировал UG2IVerticalMovementComponent.

Решения:
1. Регестрировать вручную компоненты, как сделано в это пр
2. Либо, возможно, Attach-ить USceneComponent
3. Тут ещё срабатывало, добавлять компоненту в плюсах, а не блюпринте. Но не стала так делать, т.к. тож не самый надёжный способ

Если где-то ещё не вызывается BeginPlay, то проверьте зарегестрирована ли компонента